### PR TITLE
Adding catalog example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ variable:
 export NODE_EXTRA_CA_CERTS=/path/to/ca/cert
 ```
 
+## Catalog
+Migrate the `catalog_example` directory to the default `catalog` directory.
+```
+cp -r catalog_example catalog
+```
+
 ## Development
 
 To start the app, run:

--- a/catalog_example/all.yaml
+++ b/catalog_example/all.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: app-interface-all
+  description: A collection of all systems
+spec:
+  targets:
+  - ./components/test-app.yaml

--- a/catalog_example/components/test-app.yaml
+++ b/catalog_example/components/test-app.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: test-app
+  title: Test App
+  description: |
+    Test App is a simple app that does nothing.
+
+  labels:
+    service: test-app
+    platform: test-platform
+
+
+  tags:
+    - test-app
+
+  annotations:
+    ibutsu/component-name: "cost_management"
+spec:
+  type: application 
+  system: test-app
+  owner: test-app-app-owners
+  lifecycle: OnBoarded
+  subcomponentOf: test-app-app

--- a/catalog_example/components/test-app.yaml
+++ b/catalog_example/components/test-app.yaml
@@ -16,7 +16,7 @@ metadata:
     - test-app
 
   annotations:
-    ibutsu/component-name: "cost_management"
+    ibutsu/component-name: "<----  ADD COMPONENT NAME HERE  ---->"
 spec:
   type: application 
   system: test-app


### PR DESCRIPTION
### Type of change
- Adding example catalog directory `catalog_example` test data for running Backstage plugin locally

### What's the purpose of the PR?
- Allows for easier setup for local testing
- Consistent base test app for users on cloning of plugin repo

### What's the impact of the change?
- Keeps consistent testing experience for plugin apps